### PR TITLE
Update NVivo.py

### DIFF
--- a/NVivo.py
+++ b/NVivo.py
@@ -862,11 +862,11 @@ def Normalise(args):
                     nvivoNodeReference.c.CreatedDate,
                     nvivoNodeReference.c.ModifiedBy,
                     nvivoNodeReference.c.ModifiedDate
-                ] + [
+                ] + ([
                     nvivoNodeReference.c.StartText,
                     nvivoNodeReference.c.LengthText
                 ] if args.mac else [
-                ]).where(and_(
+                ])).where(and_(
                     #nvivoNodeReference.c.ReferenceTypeId == literal_column('0'),
                     nvivoItem.c.Id == nvivoNodeReference.c.Node_Item_Id,
                     nvivoItem.c.TypeId == literal_column(NVivo.ItemType.Node),


### PR DESCRIPTION
Traceback (most recent call last):
File "NormaliseNVP.py", line 143, in 
NormaliseNVP(None)
File "NormaliseNVP.py", line 132, in NormaliseNVP
NVivo.Normalise(args)
File "C:\Users\Rui\Desktop\nvivotools-master\NVivo.py", line 873, in Normalise
nvivoNodeReference.c.StartZ.is_(None)
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\base.py", line 2166, in execute
return connection.execute(statement, *multiparams, **params)
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\base.py", line 988, in execute
return meth(self, multiparams, params)
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\sql\elements.py", line 287, in _execute_on_connection
return connection._execute_clauseelement(self, multiparams, params)
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\base.py", line 1107, in _execute_clauseelement
distilled_params,
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\base.py", line 1248, in _execute_context
e, statement, parameters, cursor, context
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\base.py", line 1466, in _handle_dbapi_exception
util.raise_from_cause(sqlalchemy_exception, exc_info)
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\util\compat.py", line 383, in raise_from_cause
reraise(type(exception), exception, tb=exc_tb, cause=cause)
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\base.py", line 1244, in _execute_context
cursor, statement, parameters, context
File "C:\Users\Rui\AppData\Roaming\Python\Python27\site-packages\sqlalchemy\engine\default.py", line 552, in do_execute
cursor.execute(statement, parameters)
File "src\pymssql.pyx", line 468, in pymssql.Cursor.execute
sqlalchemy.exc.OperationalError: (pymssql.OperationalError) (156, "Incorrect syntax near the keyword 'FROM'.DB-Lib error message 20018, severity 15:\nGeneral SQL Server error: Check messages from the SQL Server\n")
[SQL: SELECT
FROM [Item], [NodeReference]
WHERE [Item].[Id] = [NodeReference].[Node_Item_Id] AND [Item].[TypeId] = 16 AND [NodeReference].[StartZ] IS NULL]
(Background on this error at: http://sqlalche.me/e/e3q8)